### PR TITLE
Add Vercel Web Analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,11 +9,17 @@ import remarkToc from 'remark-toc';
 import remarkBreaks from 'remark-breaks';
 import robotsTxt from 'astro-robots-txt';
 import sitemap from '@astrojs/sitemap';
+import vercel from '@astrojs/vercel';
 
 // https://astro.build/config
 export default defineConfig({
     site: 'https://documents.liria.work',
     output: 'static',
+    adapter: vercel({
+        webAnalytics: {
+            enabled: true,
+        },
+    }),
     prefetch: {
         prefetchAll: true,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@astrojs/vue": "^5.0.2",
 				"@iconify-json/lucide": "^1.2.9",
 				"@iconify-json/simple-icons": "^1.2.8",
+				"@vercel/analytics": "^1.4.1",
 				"astro": "^5.0.5",
 				"astro-compressor": "^0.4.1",
 				"astro-font": "^0.1.81",
@@ -5090,9 +5091,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001687",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001687.tgz",
-			"integrity": "sha512-0S/FDhf4ZiqrTUiQ39dKeUjYRjkv7lOZU1Dgif2rIqrTzX/1wV2hfKu9TOm1IHkdSijfLswxTFzl/cvir+SLSQ==",
+			"version": "1.0.30001688",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001688.tgz",
+			"integrity": "sha512-Nmqpru91cuABu/DTCXbM2NSRHzM2uVHfPnhJ/1zEAJx/ILBRVmz3pzH4N7DZqbdG0gWClsCC05Oj0mJ/1AWMbA==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5662,9 +5663,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.72",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
-			"integrity": "sha512-ZpSAUOZ2Izby7qnZluSrAlGgGQzucmFbN0n64dYzocYxnxV5ufurpj3VgEe4cUp7ir9LmeLxNYo8bVnlM8bQHw==",
+			"version": "1.5.73",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.73.tgz",
+			"integrity": "sha512-8wGNxG9tAG5KhGd3eeA0o6ixhiNdgr0DcHWm85XPCphwZgD1lIEoi6t3VERayWao7SF7AAZTw6oARGJeVjH8Kg==",
 			"license": "ISC"
 		},
 		"node_modules/emmet": {
@@ -9252,17 +9253,16 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-			"integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+			"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"bin": {
-				"prettier": "bin/prettier.cjs"
+				"prettier": "bin-prettier.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=10.13.0"
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
@@ -10901,9 +10901,9 @@
 			}
 		},
 		"node_modules/type-fest": {
-			"version": "4.30.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.0.tgz",
-			"integrity": "sha512-G6zXWS1dLj6eagy6sVhOMQiLtJdxQBHIA9Z6HFUNLOlr6MFOgzV8wvmidtPONfPtEUv0uZsy77XJNzTAfwPDaA==",
+			"version": "4.30.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.30.1.tgz",
+			"integrity": "sha512-ojFL7eDMX2NF0xMbDwPZJ8sb7ckqtlAi1GsmgsFXvErT9kFTk1r0DuQKvrCh73M6D4nngeHJmvogF9OluXs7Hw==",
 			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=16"
@@ -12398,22 +12398,6 @@
 			},
 			"optionalDependencies": {
 				"prettier": "2.8.7"
-			}
-		},
-		"node_modules/yaml-language-server/node_modules/prettier": {
-			"version": "2.8.7",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-			"integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
-			"license": "MIT",
-			"optional": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
-			"engines": {
-				"node": ">=10.13.0"
-			},
-			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/yaml-language-server/node_modules/request-light": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@astrojs/vue": "^5.0.2",
 		"@iconify-json/lucide": "^1.2.9",
 		"@iconify-json/simple-icons": "^1.2.8",
+		"@vercel/analytics": "^1.4.1",
 		"astro": "^5.0.5",
 		"astro-compressor": "^0.4.1",
 		"astro-font": "^0.1.81",

--- a/src/layouts/main.astro
+++ b/src/layouts/main.astro
@@ -1,5 +1,6 @@
 ---
 import { AstroFont } from 'astro-font';
+import Analytics from '@vercel/analytics/astro';
 
 import Header from './header.astro';
 import Footer from './footer.astro';
@@ -31,6 +32,7 @@ import Footer from './footer.astro';
                 },
             ]}
         />
+        <Analytics />
     </head>
 
     <body class="text-neutral-100 bg-[#0b0b0b] px-8 py-5">


### PR DESCRIPTION
This pull request includes changes to integrate Vercel analytics into the project. The most important changes involve adding the Vercel adapter and analytics package, as well as updating the configuration and layout files to utilize these new features.

### Integration of Vercel Analytics:

* [`astro.config.mjs`](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR12-R22): Added the Vercel adapter with web analytics enabled in the Astro configuration.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R18): Added the `@vercel/analytics` package to the dependencies.
* [`src/layouts/main.astro`](diffhunk://#diff-7a6167a0bb4d8b17918331a347d50f8800db1061a49cf1aef865dbde00ffce4eR3): Imported the `Analytics` component from `@vercel/analytics/astro` and included it in the layout. [[1]](diffhunk://#diff-7a6167a0bb4d8b17918331a347d50f8800db1061a49cf1aef865dbde00ffce4eR3) [[2]](diffhunk://#diff-7a6167a0bb4d8b17918331a347d50f8800db1061a49cf1aef865dbde00ffce4eR35)